### PR TITLE
Remove site id when dealing with reprocessor sites

### DIFF
--- a/src/EPR.Accreditation.API/Controllers/OverseasSiteController.cs
+++ b/src/EPR.Accreditation.API/Controllers/OverseasSiteController.cs
@@ -16,13 +16,13 @@ namespace EPR.Accreditation.API.Controllers
             _accreditationService = accreditationService ?? throw new ArgumentNullException(nameof(accreditationService));
         }
 
-        [HttpGet]
+        [HttpGet("{siteExternalId}")]
         [ProducesResponseType(typeof(DTO.OverseasReprocessingSite), 200)]
         public async Task<IActionResult> GetSite(
             Guid externalId,
             Guid siteExternalId)
         {
-            var site = await _accreditationService.GetSite(
+            var site = await _accreditationService.GetOverseasSite(
                 externalId,
                 siteExternalId);
 

--- a/src/EPR.Accreditation.API/Controllers/OverseasSiteMaterialControllerController.cs
+++ b/src/EPR.Accreditation.API/Controllers/OverseasSiteMaterialControllerController.cs
@@ -24,7 +24,6 @@ namespace EPR.Accreditation.API.Controllers
         {
             var material = await _accreditationService.GetMaterial(
                 externalId,
-                null,
                 overseasSiteExternalId,
                 materialExternalId);
 
@@ -45,7 +44,6 @@ namespace EPR.Accreditation.API.Controllers
 
             var materialId = await _accreditationService.CreateMaterial(
                 externalId,
-                null,
                 overseasExternalSiteId,
                 accreditationMaterial);
 
@@ -64,7 +62,6 @@ namespace EPR.Accreditation.API.Controllers
 
             await _accreditationService.UpdateMaterail(
                 externalId,
-                null,
                 siteExternalId,
                 materialExternalId,
                 accreditationMaterial);

--- a/src/EPR.Accreditation.API/Controllers/SiteController.cs
+++ b/src/EPR.Accreditation.API/Controllers/SiteController.cs
@@ -16,15 +16,13 @@ namespace EPR.Accreditation.API.Controllers
             _accreditationService = accreditationService ?? throw new ArgumentNullException(nameof(accreditationService));
         }
 
-        [HttpGet("{siteExternalId}")]
+        [HttpGet]
         [ProducesResponseType(typeof(DTO.Site), 200)]
         public async Task<IActionResult> GetSite(
-            Guid externalId,
-            Guid siteExternalId)
+            Guid externalId)
         {
             var site = await _accreditationService.GetSite(
-                externalId,
-                siteExternalId);
+                externalId);
 
             if (site == null)
                 return NotFound();
@@ -46,9 +44,13 @@ namespace EPR.Accreditation.API.Controllers
         }
 
         [HttpPut]
-        public async Task<IActionResult> UpdateSite(DTO.Site site)
+        public async Task<IActionResult> UpdateSite(
+            Guid externalId,
+            DTO.Site site)
         {
-            await _accreditationService.UpdateSite(site);
+            await _accreditationService.UpdateSite(
+                externalId,
+                site);
 
             return Ok();
         }

--- a/src/EPR.Accreditation.API/Controllers/SiteMaterialController.cs
+++ b/src/EPR.Accreditation.API/Controllers/SiteMaterialController.cs
@@ -5,7 +5,7 @@ using DTO = EPR.Accreditation.API.Common.Dtos;
 namespace EPR.Accreditation.API.Controllers
 {
     [ApiController]
-    [Route("api/Accreditation/{externalId}/Site/{siteExternalId}/Material")]
+    [Route("api/Accreditation/{externalId}/Site/Material")]
     public class SiteMaterialController : ControllerBase
     {
         protected readonly IAccreditationService _accreditationService;
@@ -20,12 +20,10 @@ namespace EPR.Accreditation.API.Controllers
         [ProducesResponseType(typeof(DTO.AccreditationMaterial), 200)]
         public async Task<IActionResult> GetSiteMaterial(
             Guid externalId,
-            Guid siteExternalId,
             Guid materialExternalId)
         {
             var material = await _accreditationService.GetMaterial(
                 externalId,
-                siteExternalId,
                 null,
                 materialExternalId);
 
@@ -38,7 +36,6 @@ namespace EPR.Accreditation.API.Controllers
         [HttpPost()]
         public async Task<IActionResult> CreateSiteMaterial(
             Guid externalId,
-            Guid siteExternalId,
             [FromBody] DTO.AccreditationMaterial accreditationMaterial)
         {
             if (accreditationMaterial == null)
@@ -46,7 +43,6 @@ namespace EPR.Accreditation.API.Controllers
 
             var materialId = await _accreditationService.CreateMaterial(
                 externalId,
-                siteExternalId,
                 null,
                 accreditationMaterial);
 
@@ -56,13 +52,11 @@ namespace EPR.Accreditation.API.Controllers
         [HttpPut("{materialExternalId}")]
         public async Task<IActionResult> UpdateSiteMaterial(
             Guid externalId,
-            Guid siteExternalId,
             Guid materialExternalId,
             [FromBody] DTO.AccreditationMaterial accreditationMaterial)
         {
             await _accreditationService.UpdateMaterail(
                 externalId,
-                siteExternalId,
                 null,
                 materialExternalId,
                 accreditationMaterial);

--- a/src/EPR.Accreditation.API/Repositories/Interfaces/IRepository.cs
+++ b/src/EPR.Accreditation.API/Repositories/Interfaces/IRepository.cs
@@ -10,7 +10,6 @@ namespace EPR.Accreditation.API.Repositories.Interfaces
 
         Task<Guid> AddAccreditationMaterial(
             Guid externalId,
-            Guid? siteId,
             Guid? overseasSiteId,
             DTO.AccreditationMaterial accreditationMaterial);
 
@@ -24,7 +23,6 @@ namespace EPR.Accreditation.API.Repositories.Interfaces
 
         Task UpdateMaterial(
             Guid externalId,
-            Guid? siteId,
             Guid? overseasSiteId,
             Guid materialExternalId,
             DTO.AccreditationMaterial material);
@@ -41,19 +39,19 @@ namespace EPR.Accreditation.API.Repositories.Interfaces
 
         Task<DTO.AccreditationMaterial> GetMaterial(
             Guid externalId,
-            Guid? siteExternalId,
             Guid? overseasSiteExternalId,
             Guid materialExternalId);
 
         Task<DTO.Site> GetSite(
-            Guid id,
-            Guid siteExternalId);
+            Guid id);
 
         Task<Guid> CreateSite(
             Guid externalId,
             DTO.Site site);
 
-        Task UpdateSite(DTO.Site site);
+        Task UpdateSite(
+            Guid externalId, 
+            DTO.Site site);
 
         Task<DTO.OverseasReprocessingSite> GetOverseasSite(
             Guid id,

--- a/src/EPR.Accreditation.API/Repositories/Repository.cs
+++ b/src/EPR.Accreditation.API/Repositories/Repository.cs
@@ -195,68 +195,31 @@ namespace EPR.Accreditation.API.Repositories
             await _accreditationContext.SaveChangesAsync();
         }
 
-        protected async Task<Data.AccreditationMaterial> GetAccreditationSiteMaterial(
-            Guid externalId,
-            Guid? overseasSiteExternalId,
-            Guid materialExternalId)
-        {
-            var entity = default(Data.AccreditationMaterial);
-
-            if (overseasSiteExternalId == null)
-            {
-                // get the site based material
-                entity = await _accreditationContext
-                    .Accreditation
-                    .Include(a => a.Site.AccreditationMaterials)
-                        .ThenInclude(am => am.Material)
-                    .Include(a => a.Site.AccreditationMaterials)
-                        .ThenInclude(am => am.MaterialReprocessorDetails)
-                    .Where(a =>
-                        a.ExternalId == externalId &&
-                        a.Site != null &&
-                        a.Site.AccreditationMaterials.Any(m => m.ExternalId == materialExternalId))
-                    .Select(a =>
-                        a.Site.AccreditationMaterials.FirstOrDefault(m => m.ExternalId == materialExternalId))
-                    .SingleOrDefaultAsync();
-            }
-            else
-            {
-                // get the overseas site based material
-                entity = await _accreditationContext
-                    .AccreditationMaterial
-                    .Include(am => am.Material)
-                    .Include(am => am.MaterialReprocessorDetails)
-                    .Where(m =>
-                        m.ExternalId == materialExternalId &&
-                        m.OverseasReprocessingSite != null &&
-                        m.OverseasReprocessingSite.ExternalId == overseasSiteExternalId &&
-                        m.OverseasReprocessingSite.Accreditation.ExternalId == externalId)
-                    .Select(m => m)
-                    .SingleOrDefaultAsync();
-            }
-
-            return entity;
-        }
+        
 
         public async Task<DTO.AccreditationMaterial> GetMaterial(
             Guid externalId,
-            Guid? siteExternalId,
             Guid? overseasSiteExternalId,
             Guid materialExternalId)
         {
-            var entity = await GetAccreditationSiteMaterial(externalId, siteExternalId, overseasSiteExternalId, materialExternalId);
+            var entity = await GetAccreditationSiteMaterial(
+                externalId, 
+                overseasSiteExternalId, 
+                materialExternalId);
 
             return _mapper.Map<DTO.AccreditationMaterial>(entity);
         }
 
         public async Task UpdateMaterial(
             Guid externalId,
-            Guid? siteExternalId,
             Guid? overseasSiteExternalId,
             Guid materialExternalId,
             DTO.AccreditationMaterial material)
         {
-            var entity = await GetAccreditationSiteMaterial(externalId, siteExternalId, overseasSiteExternalId, materialExternalId);
+            var entity = await GetAccreditationSiteMaterial(
+                externalId, 
+                overseasSiteExternalId, 
+                materialExternalId);
 
             // TODO need to handle an entity that's not found better here
             if (entity == null)
@@ -276,49 +239,6 @@ namespace EPR.Accreditation.API.Repositories
 
             // save the changes
             await _accreditationContext.SaveChangesAsync();
-        }
-
-        public async Task<DTO.AccreditationMaterial> GetMaterial(
-            Guid externalId,
-            Guid? overseasSiteExternalId,
-            Guid materialExternalId)
-        {
-            var entity = default(Data.AccreditationMaterial);
-
-            if (overseasSiteExternalId == null)
-            {
-                // get the site based material
-                entity = await _accreditationContext
-                    .Accreditation
-                    .Include(a => a.Site.AccreditationMaterials)
-                        .ThenInclude(am => am.Material)
-                    .Include(a => a.Site.AccreditationMaterials)                        
-                        .ThenInclude(am => am.MaterialReprocessorDetails)
-                    .Where(a =>
-                        a.ExternalId == externalId &&
-                    a.Site != null &&
-                        a.Site.AccreditationMaterials.Any(m => m.ExternalId == materialExternalId))
-                    .Select(a =>
-                        a.Site.AccreditationMaterials.FirstOrDefault(m => m.ExternalId == materialExternalId))
-                    .SingleOrDefaultAsync();
-            }
-            else
-            {
-                // get the overseas site based material
-                entity = await _accreditationContext
-                    .AccreditationMaterial
-                    .Include(am => am.Material)
-                    .Include(am => am.MaterialReprocessorDetails)
-                    .Where(m =>
-                        m.ExternalId == materialExternalId &&
-                        m.OverseasReprocessingSite != null &&
-                        m.OverseasReprocessingSite.ExternalId == overseasSiteExternalId &&
-                        m.OverseasReprocessingSite.Accreditation.ExternalId == externalId)
-                    .Select(m => m)
-                    .SingleOrDefaultAsync();
-            }
-
-            return _mapper.Map<DTO.AccreditationMaterial>(entity);
         }
 
         public async Task<IEnumerable<DTO.Country>> GetCountries()
@@ -493,6 +413,49 @@ namespace EPR.Accreditation.API.Repositories
                 .Material
                 .Select(m => _mapper.Map<DTO.Material>(m))
                 .ToListAsync();
+        }
+
+        protected async Task<Data.AccreditationMaterial> GetAccreditationSiteMaterial(
+            Guid externalId,
+            Guid? overseasSiteExternalId,
+            Guid materialExternalId)
+        {
+            var entity = default(Data.AccreditationMaterial);
+
+            if (overseasSiteExternalId == null)
+            {
+                // get the site based material
+                entity = await _accreditationContext
+                    .Accreditation
+                    .Include(a => a.Site.AccreditationMaterials)
+                        .ThenInclude(am => am.Material)
+                    .Include(a => a.Site.AccreditationMaterials)
+                        .ThenInclude(am => am.MaterialReprocessorDetails)
+                    .Where(a =>
+                        a.ExternalId == externalId &&
+                        a.Site != null &&
+                        a.Site.AccreditationMaterials.Any(m => m.ExternalId == materialExternalId))
+                    .Select(a =>
+                        a.Site.AccreditationMaterials.FirstOrDefault(m => m.ExternalId == materialExternalId))
+                    .SingleOrDefaultAsync();
+            }
+            else
+            {
+                // get the overseas site based material
+                entity = await _accreditationContext
+                    .AccreditationMaterial
+                    .Include(am => am.Material)
+                    .Include(am => am.MaterialReprocessorDetails)
+                    .Where(m =>
+                        m.ExternalId == materialExternalId &&
+                        m.OverseasReprocessingSite != null &&
+                        m.OverseasReprocessingSite.ExternalId == overseasSiteExternalId &&
+                        m.OverseasReprocessingSite.Accreditation.ExternalId == externalId)
+                    .Select(m => m)
+                    .SingleOrDefaultAsync();
+            }
+
+            return entity;
         }
     }
 }

--- a/src/EPR.Accreditation.API/Repositories/Repository.cs
+++ b/src/EPR.Accreditation.API/Repositories/Repository.cs
@@ -1,7 +1,7 @@
 ﻿using AutoMapper;
 using EPR.Accreditation.API.Common.Data;
+using EPR.Accreditation.API.Common.Data.DataModels;
 using EPR.Accreditation.API.Common.Data.Enums;
-using EPR.Accreditation.API.Common.Dtos;
 using EPR.Accreditation.API.Helpers;
 using EPR.Accreditation.API.Repositories.Interfaces;
 using Microsoft.EntityFrameworkCore;
@@ -34,20 +34,18 @@ namespace EPR.Accreditation.API.Repositories
 
         public async Task<Guid> AddAccreditationMaterial(
             Guid externalId,
-            Guid? siteId,
             Guid? overseasSiteId,
             DTO.AccreditationMaterial material)
         {
             var entity = _mapper.Map<Data.AccreditationMaterial>(material);
 
-            if (siteId != null)
+            if (overseasSiteId == null)
             {
                 entity.SiteId = await _accreditationContext
                     .Accreditation
                     .Where(a =>
                         a.ExternalId == externalId &&
-                        a.SiteId.HasValue &&
-                        a.Site.ExternalId == siteId)
+                        a.SiteId.HasValue)
                     .Select(a => a.SiteId)
                     .SingleAsync();
             }
@@ -60,7 +58,6 @@ namespace EPR.Accreditation.API.Repositories
                         o.ExternalId == overseasSiteId)
                     .Select(o => o.Id)
                     .SingleAsync();
-
             }
 
             await _accreditationContext.AccreditationMaterial.AddAsync(entity);
@@ -200,14 +197,13 @@ namespace EPR.Accreditation.API.Repositories
 
         public async Task UpdateMaterial(
             Guid externalId,
-            Guid? siteExternalId,
             Guid? overseasSiteExternalId,
             Guid materialExternalId,
             DTO.AccreditationMaterial material)
         {
             var entity = default(Data.AccreditationMaterial);
 
-            if (siteExternalId != null)
+            if (overseasSiteExternalId == null)
             {
                 // get  the site based material
                 entity = await _accreditationContext
@@ -215,7 +211,6 @@ namespace EPR.Accreditation.API.Repositories
                     .Where(a =>
                         a.ExternalId == externalId &&
                         a.Site != null &&
-                        a.Site.ExternalId == siteExternalId &&
                         a.Site.AccreditationMaterials.Any(m => m.ExternalId == materialExternalId))
                     .Select(a =>
                         a.Site.AccreditationMaterials.FirstOrDefault(m => m.ExternalId == materialExternalId))
@@ -237,7 +232,7 @@ namespace EPR.Accreditation.API.Repositories
 
             // TODO need to handle an entity that's not found better here
             if (entity == null)
-                throw new NotFoundException($"Material not found for External ID: {externalId}, Site External ID: {siteExternalId}, Overseas External ID: {overseasSiteExternalId}, Material External ID: {materialExternalId}");
+                throw new NotFoundException($"Material not found for External ID: {externalId}, Overseas External ID: {overseasSiteExternalId}, Material External ID: {materialExternalId}");
 
             // copy the updates over to the db entity
             entity = _mapper.Map(material, entity);
@@ -257,13 +252,12 @@ namespace EPR.Accreditation.API.Repositories
 
         public async Task<DTO.AccreditationMaterial> GetMaterial(
             Guid externalId,
-            Guid? siteExternalId,
             Guid? overseasSiteExternalId,
             Guid materialExternalId)
         {
             var entity = default(Data.AccreditationMaterial);
 
-            if (siteExternalId != null)
+            if (overseasSiteExternalId == null)
             {
                 // get the site based material
                 entity = await _accreditationContext
@@ -275,7 +269,6 @@ namespace EPR.Accreditation.API.Repositories
                     .Where(a =>
                         a.ExternalId == externalId &&
                     a.Site != null &&
-                        a.Site.ExternalId == siteExternalId &&
                         a.Site.AccreditationMaterials.Any(m => m.ExternalId == materialExternalId))
                     .Select(a =>
                         a.Site.AccreditationMaterials.FirstOrDefault(m => m.ExternalId == materialExternalId))
@@ -300,7 +293,7 @@ namespace EPR.Accreditation.API.Repositories
             return _mapper.Map<DTO.AccreditationMaterial>(entity);
         }
 
-        public async Task<IEnumerable<Country>> GetCountries()
+        public async Task<IEnumerable<DTO.Country>> GetCountries()
         {
             return await _accreditationContext
                 .Country
@@ -309,20 +302,19 @@ namespace EPR.Accreditation.API.Repositories
                 .ToListAsync();
         }
 
-        public async Task<Site> GetSite(
-            Guid id,
-            Guid siteExternalId)
+        public async Task<DTO.Site> GetSite(
+            Guid id)
         {
             return await _accreditationContext
                 .Accreditation
-                .Where(a => a.ExternalId == id && a.Site.ExternalId == siteExternalId)
+                .Where(a => a.ExternalId == id && a.SiteId.HasValue)
                 .Select(a => _mapper.Map<DTO.Site>(a.Site))
                 .SingleOrDefaultAsync();
         }
 
         public async Task<Guid> CreateSite(
             Guid externalId,
-            Site site)
+            DTO.Site site)
         {
             // add the site id to the accreditation record
             var accreditionEntity = await _accreditationContext
@@ -348,9 +340,23 @@ namespace EPR.Accreditation.API.Repositories
             return entity.ExternalId;
         }
 
-        public Task UpdateSite(Site site)
+        public async Task UpdateSite(
+            Guid externalId,
+            DTO.Site site)
         {
-            throw new NotImplementedException();
+            // get site from the accreditation
+            var entity = await _accreditationContext
+                .Accreditation
+                .Where(a => a.ExternalId == externalId
+                    && a.SiteId.HasValue)
+                .Select(a => a.Site)
+                .SingleOrDefaultAsync();
+
+            if (entity == null)
+                throw new NotFoundException();
+
+            entity = _mapper.Map(site, entity);
+            await _accreditationContext.SaveChangesAsync();
         }
 
         public async Task<DTO.OverseasReprocessingSite> GetOverseasSite(
@@ -392,7 +398,7 @@ namespace EPR.Accreditation.API.Repositories
             throw new NotImplementedException();
         }
 
-        public async Task<SaveAndComeBack> GetSaveAndComeBack(Guid externalId)
+        public async Task<DTO.SaveAndComeBack> GetSaveAndComeBack(Guid externalId)
         {
             var saveAndContinue = await _accreditationContext
                 .SaveAndComeBack
@@ -453,7 +459,7 @@ namespace EPR.Accreditation.API.Repositories
             await _accreditationContext.SaveChangesAsync();
         }
 
-        public async Task<IEnumerable<Material>> GetMaterials()
+        public async Task<IEnumerable<DTO.Material>> GetMaterials()
         {
             return await _accreditationContext
                 .Material

--- a/src/EPR.Accreditation.API/Services/AccreditationService.cs
+++ b/src/EPR.Accreditation.API/Services/AccreditationService.cs
@@ -29,23 +29,13 @@ namespace EPR.Accreditation.API.Services
 
         public async Task<Guid> CreateMaterial(
             Guid externalId,
-            Guid? siteId,
             Guid? overseasSiteId,
             AccreditationMaterial accreditationMaterial)
         {
-            if (siteId == null &&
-                overseasSiteId == null)
-                throw new ArgumentNullException("Neither site Id or overseas site Id have been provided");
-
-            if (siteId != null &&
-                overseasSiteId != null)
-                throw new ArgumentException("Cannopt add a material with both a site Id and overseas site Id");
-
             accreditationMaterial.ExternalId = Guid.NewGuid();
 
             return await _repository.AddAccreditationMaterial(
                 externalId,
-                siteId,
                 overseasSiteId,
                 accreditationMaterial);
         }
@@ -97,22 +87,12 @@ namespace EPR.Accreditation.API.Services
 
         public async Task UpdateMaterail(
             Guid externalId,
-            Guid? siteId,
             Guid? overseasSiteId,
             Guid materialExternalId,
             AccreditationMaterial accreditationMaterial)
         {
-            if (siteId == null &&
-                overseasSiteId == null)
-                throw new ArgumentNullException("Neither site Id or overseas site Id have been provided");
-
-            if (siteId != null &&
-                overseasSiteId != null)
-                throw new ArgumentException("Cannopt add a material with both a site Id and overseas site Id");
-
             await _repository.UpdateMaterial(
                 externalId,
-                siteId,
                 overseasSiteId,
                 materialExternalId,
                 accreditationMaterial);
@@ -120,30 +100,19 @@ namespace EPR.Accreditation.API.Services
 
         public async Task<AccreditationMaterial> GetMaterial(
             Guid externalId,
-            Guid? siteExternalId,
             Guid? overseasSiteExternalId,
             Guid materialExternalId)
         {
-            if (siteExternalId == null &&
-                overseasSiteExternalId == null)
-                throw new ArgumentNullException("Neither site Id or overseas site Id have been provided");
-
-            if (siteExternalId != null &&
-                overseasSiteExternalId != null)
-                throw new ArgumentException("Cannopt add a material with both a site Id and overseas site Id");
-
             return await _repository.GetMaterial(
                 externalId,
-                siteExternalId,
                 overseasSiteExternalId,
                 materialExternalId);
         }
 
         public async Task<DTO.Site> GetSite(
-            Guid externalId,
-            Guid siteExternalId)
+            Guid externalId)
         {
-            return await _repository.GetSite(externalId, siteExternalId);
+            return await _repository.GetSite(externalId);
         }
 
         public async Task<Guid> CreateSite(
@@ -155,16 +124,20 @@ namespace EPR.Accreditation.API.Services
                 site);
         }
 
-        public Task UpdateSite(Site site)
+        public async Task UpdateSite(
+            Guid externalId,
+            Site site)
         {
-            throw new NotImplementedException();
+            await _repository.UpdateSite(
+                externalId,
+                site);
         }
 
         public async Task<DTO.OverseasReprocessingSite> GetOverseasSite(
             Guid externalId,
-            Guid siteExternalId)
+            Guid overseasSiteExternalId)
         {
-            return await _repository.GetOverseasSite(externalId, siteExternalId);
+            return await _repository.GetOverseasSite(externalId, overseasSiteExternalId);
         }
 
         public async Task<Guid> CreateOverseasSite(

--- a/src/EPR.Accreditation.API/Services/Interfaces/IAccreditationService.cs
+++ b/src/EPR.Accreditation.API/Services/Interfaces/IAccreditationService.cs
@@ -8,7 +8,6 @@ namespace EPR.Accreditation.API.Services.Interfaces
 
         Task<Guid> CreateMaterial(
             Guid externalId,
-            Guid? siteId,
             Guid? overseasSiteId,
             DTO.AccreditationMaterial accreditationMaterial);
 
@@ -22,7 +21,6 @@ namespace EPR.Accreditation.API.Services.Interfaces
 
         Task UpdateMaterail(
             Guid externalId,
-            Guid? siteId,
             Guid? overseasSiteId,
             Guid materialExternalId,
             DTO.AccreditationMaterial accreditationMaterial);
@@ -39,23 +37,23 @@ namespace EPR.Accreditation.API.Services.Interfaces
 
         Task<DTO.AccreditationMaterial> GetMaterial(
             Guid externalId,
-            Guid? siteExternalId,
             Guid? overseasSiteExternalId,
             Guid materialExternalId);
 
         Task<DTO.Site> GetSite(
-            Guid externalId,
-            Guid siteExternalId);
+            Guid externalId);
 
         Task<Guid> CreateSite(
             Guid externalId,
             DTO.Site site);
 
-        Task UpdateSite(DTO.Site site);
+        Task UpdateSite(
+            Guid externalId,
+            DTO.Site site);
 
         Task<DTO.OverseasReprocessingSite> GetOverseasSite(
             Guid externalId,
-            Guid siteExternalId);
+            Guid overseasSiteExternalId);
 
         Task<Guid> CreateOverseasSite(
             Guid externalId,


### PR DESCRIPTION
This is because an accreditation only has one site and therefore a unique identifier is only required for accreditation